### PR TITLE
Fixed gr.h order

### DIFF
--- a/lib/gr/gr.h
+++ b/lib/gr/gr.h
@@ -182,13 +182,13 @@ DLLEXPORT void gr_inqborderwidth(double *);
 DLLEXPORT void gr_setbordercolorind(int);
 DLLEXPORT void gr_inqbordercolorind(int *);
 DLLEXPORT void gr_setprojectiontype(int);
-DLLEXPORT void gr_setperspectiveprojection(double, double, double);
-DLLEXPORT void gr_settransformationparameters(double, double, double, double, double, double, double, double, double);
-DLLEXPORT void gr_setorthographicprojection(double, double, double, double, double, double);
 DLLEXPORT void gr_inqprojectiontype(int *);
+DLLEXPORT void gr_setperspectiveprojection(double, double, double);
+DLLEXPORT void gr_inqperspectiveprojection(double *, double *, double *);
+DLLEXPORT void gr_settransformationparameters(double, double, double, double, double, double, double, double, double);
 DLLEXPORT void gr_inqtransformationparameters(double *, double *, double *, double *, double *, double *, double *,
                                               double *, double *);
-DLLEXPORT void gr_inqperspectiveprojection(double *, double *, double *);
+DLLEXPORT void gr_setorthographicprojection(double, double, double, double, double, double);
 DLLEXPORT void gr_inqorthographicprojection(double *, double *, double *, double *, double *, double *);
 DLLEXPORT void gr_camerainteraction(double, double, double, double);
 DLLEXPORT void gr_setwindow3d(double, double, double, double, double, double);


### PR DESCRIPTION
Hello. GR developers. 

* Ordered the inq function next to the set function.
* Motivation: Make it easier to develop GR bindings.
* This is just a suggestion. 

Thank you.