### PR TITLE
added gr_inqcharheight to lib/gr/gr.h

### DIFF
--- a/lib/gr/gr.h
+++ b/lib/gr/gr.h
@@ -64,6 +64,7 @@ DLLEXPORT void gr_setcharspace(double);
 DLLEXPORT void gr_settextcolorind(int);
 DLLEXPORT void gr_inqtextcolorind(int *);
 DLLEXPORT void gr_setcharheight(double);
+DLLEXPORT void gr_inqcharheight(double *);
 DLLEXPORT void gr_setcharup(double, double);
 DLLEXPORT void gr_settextpath(int);
 DLLEXPORT void gr_settextalign(int, int);


### PR DESCRIPTION
Hello

I've found `gr_inqcharheight` is defined in [gr.c](https://github.com/sciapp/gr/blob/master/lib/gr/gr.c#L2882-L2886) but not exported.
