### PR TITLE
Add support for pkg-config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ dist/
 *.so.dSYM
 *.dylib
 *.app
+*.pc
 gr*.deb
 gr*.rpm
 cmake-build-*/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -895,6 +895,13 @@ if(GR_INSTALL)
   install(FILES "${CMAKE_CURRENT_BINARY_DIR}/GRConfig.cmake" "${CMAKE_CURRENT_BINARY_DIR}/GRConfigVersion.cmake"
           DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/GR"
   )
+  foreach(PACKAGE gr gr3 gks grm)
+    configure_file("${PACKAGE}.pc.in"
+                   "${CMAKE_CURRENT_BINARY_DIR}/${PACKAGE}.pc"
+                   @ONLY)
+    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${PACKAGE}.pc"
+            DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig/")
+  endforeach()
   install(
     TARGETS gks_shared gr_shared gr3_shared grm_shared
     EXPORT GRTargets

--- a/gks.pc.in
+++ b/gks.pc.in
@@ -1,0 +1,10 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
+sopath=${libdir}/libGKS@GR_SHARED_LIBRARY_SUFFIX@
+
+Name: GKS
+Description: GKS is Graphical Kernel System
+Version: @GR_VERSION@
+Cflags: -I${includedir}
+Libs: -L${libdir} -lGKS

--- a/gr.pc.in
+++ b/gr.pc.in
@@ -1,0 +1,10 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
+sopath=${libdir}/libGR@GR_SHARED_LIBRARY_SUFFIX@
+
+Name: GR
+Description: GR is a universal framework for visualization applications
+Version: @GR_VERSION@
+Cflags: -I${includedir}
+Libs: -L${libdir} -lGR

--- a/gr3.pc.in
+++ b/gr3.pc.in
@@ -1,0 +1,10 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
+sopath=${libdir}/libGR3@GR_SHARED_LIBRARY_SUFFIX@
+
+Name: GR3
+Description: GR3 is a software library for simple visualization of 3D scenes
+Version: @GR_VERSION@
+Cflags: -I${includedir}
+Libs: -L${libdir} -lGR3

--- a/grm.pc.in
+++ b/grm.pc.in
@@ -1,0 +1,10 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
+sopath=${libdir}/libGRM@GR_SHARED_LIBRARY_SUFFIX@
+
+Name: GRM
+Description: GRM is the meta layer for GR and GR3
+Version: @GR_VERSION@
+Cflags: -I${includedir}
+Libs: -L${libdir} -lGRM


### PR DESCRIPTION
If we have `.pc` files for GR, we can detect `GRDIR` by `pkg-config --variable=prefix gr` and `libGR.so` path by `pkg-config --variable=sopath gr`.