### PR TITLE
Use gks_strdup() instead of strdup()

### DIFF
--- a/lib/gks/gkscore.h
+++ b/lib/gks/gkscore.h
@@ -1,6 +1,8 @@
 #ifndef _GKSCORE_H_
 #define _GKSCORE_H_
 
+#include <stddef.h>
+
 #ifdef _WIN32
 
 #include <windows.h> /* required for all Windows applications */

--- a/lib/grm/datatype/string_list.c
+++ b/lib/grm/datatype/string_list.c
@@ -4,8 +4,6 @@
 #define _POSIX_C_SOURCE 200112L
 #endif
 
-#include <string.h>
-
 #include "gkscore.h"
 #include "string_list_int.h"
 
@@ -22,7 +20,7 @@ error_t string_list_entry_copy(string_list_entry_t *copy, const string_list_cons
 {
   string_list_entry_t _copy;
 
-  _copy = strdup(entry);
+  _copy = gks_strdup(entry);
   if (_copy == NULL)
     {
       return ERROR_MALLOC;


### PR DESCRIPTION
This suppress the following warning:

    lib/grm/datatype/string_list.c: In function 'string_list_entry_copy':
    lib/grm/datatype/string_list.c:23:9: warning: assignment to 'string_list_entry_t' {aka 'char *'} from 'int' makes pointer from integer without a cast [-Wint-conversion]
       23 |   _copy = strdup(entry);
          |         ^