### PR TITLE
Try LOAD_LIBRARY_SEARCH_DEFAULT_DIRS if LOAD_WITH_ALTERED_SEARCH_PATH fails

### DIFF
--- a/lib/gks/plugin.c
+++ b/lib/gks/plugin.c
@@ -51,6 +51,15 @@ static void *load_library(const char *name)
       GetEnvironmentVariableW(L"GRDIR", grdir, MAX_PATH);
       StringCbPrintfW(w_pathname, MAX_PATH, L"%ws\\bin\\%S.%S", grdir, name, EXTENSION);
       handle = LoadLibraryExW(w_pathname, NULL, LOAD_WITH_ALTERED_SEARCH_PATH);
+      if (handle == NULL)
+        {
+          //Try loading with default search path if altered search path fails
+          //  This value is a combination of LOAD_LIBRARY_SEARCH_APPLICATION_DIR,
+          //  LOAD_LIBRARY_SEARCH_USER_DIRS, and LOAD_LIBRARY_SEARCH_SYSTEM32.
+          //  They are searched in that order.
+          // Use AddDllDirectory to add additional user directories to the search.
+          handle = LoadLibraryExW(w_pathname, NULL, LOAD_LIBRARY_SEARCH_DEFAULT_DIRS);
+        }
     }
 #else
   handle = dlopen(pathname, RTLD_LAZY);


### PR DESCRIPTION
If `LoadLibraryExW(..., LOAD_WITH_ALTERED_SEARCH_PATH)` fails, then this tries `LoadLibraryExW(... , LOAD_LIBRARY_SEARCH_DEFAULT_DIRS)`.

# LOAD_LIBRARY_SEARCH_DEFAULT_DIRS

> This value is a combination of LOAD_LIBRARY_SEARCH_APPLICATION_DIR, LOAD_LIBRARY_SEARCH_SYSTEM32, and LOAD_LIBRARY_SEARCH_USER_DIRS. Directories in the standard search path are not searched. **This value cannot be combined with LOAD_WITH_ALTERED_SEARCH_PATH.**
> This value represents the recommended maximum number of directories an application should include in its DLL search path.
> 
> 

# LOAD_LIBRARY_SEARCH_USER_DIRS

> If this value is used, directories added using the [AddDllDirectory](https://learn.microsoft.com/en-us/windows/desktop/api/libloaderapi/nf-libloaderapi-adddlldirectory) or the [SetDllDirectory](https://learn.microsoft.com/en-us/windows/desktop/api/winbase/nf-winbase-setdlldirectorya) function are searched for the DLL and its dependencies. If more than one directory has been added, the order in which the directories are searched is unspecified. Directories in the standard search path are not searched. **This value cannot be combined with LOAD_WITH_ALTERED_SEARCH_PATH**.

# Order

> An application can specify the directories to search for a single LoadLibraryEx call by using the LOAD_LIBRARY_SEARCH_* flags. If more than one LOAD_LIBRARY_SEARCH flag is specified, the directories are searched in the following order:
> 
> 1. The directory that contains the DLL (LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR). This directory is searched only for dependencies of the DLL to be loaded.
> 2. The application directory (LOAD_LIBRARY_SEARCH_APPLICATION_DIR).
> 3. Paths explicitly added to the application search path with the [AddDllDirectory](https://learn.microsoft.com/en-us/windows/desktop/api/libloaderapi/nf-libloaderapi-adddlldirectory) function (LOAD_LIBRARY_SEARCH_USER_DIRS) or the [SetDllDirectory](https://learn.microsoft.com/en-us/windows/desktop/api/winbase/nf-winbase-setdlldirectorya) function. If more than one path has been added, the order in which the paths are searched is unspecified.
> 4. The System32 directory (LOAD_LIBRARY_SEARCH_SYSTEM32).
> 
> 