### PR TITLE
grm: fix build error with MSYS2 + clang

### DIFF
--- a/lib/grm/grplot/util.cxx
+++ b/lib/grm/grplot/util.cxx
@@ -1,3 +1,15 @@
+#if defined __unix__ || defined __APPLE__
+#include <cerrno>
+#include <cstdlib>
+#include <cstring>
+#endif
+#include <array>
+#include <exception>
+#include <iostream>
+#include <memory>
+#include <sstream>
+#include <vector>
+
 #if defined __APPLE__
 #include <libgen.h>
 #include <mach-o/dyld.h>
@@ -15,17 +27,6 @@
 #else
 #error "Unsupported system"
 #endif
-#if defined __unix__ || defined __APPLE__
-#include <cerrno>
-#include <cstdlib>
-#include <cstring>
-#endif
-#include <array>
-#include <exception>
-#include <iostream>
-#include <memory>
-#include <sstream>
-#include <vector>
 
 #include "util.hxx"
 
@@ -97,10 +98,10 @@ GetLastErrorError::GetLastErrorError()
 {
   unsigned int errorCode = GetLastError();
   std::stringstream whatStream;
-  char *errorMessage = nullptr;
+  LPTSTR errorMessage = nullptr;
 
   if (!FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
-                     nullptr, errorCode, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPSTR)&errorMessage, 0, nullptr))
+                     nullptr, errorCode, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPTSTR)&errorMessage, 0, nullptr))
     {
       throwOrTerminate_(FormatMessageError());
     }


### PR DESCRIPTION
There are 2 problems:

1. `#include <array>` and some built-in headers don't work after `#include <strsafe.h>`
2. We need to use `LPTSTR` instead of `char *`for `FormatMessage()` because `FormatMessage()` may be replaced with `FormatMessageW()`

Error log:

    FAILED: CMakeFiles/grplot.dir/lib/grm/grplot/util.cxx.obj
    C:\msys64\clang64\bin\c++.exe -DGR_STATIC_LIB -DHAVE_ZLIB -DMINGW_HAS_SECURE_API=1 -DQT_CORE_LIB -DQT_GUI_LIB -DQT_NEEDS_QMAIN -DQT_NO_DEBUG -DQT_WIDGETS_LIB -DUNICODE -DWIN32 -DWIN64 -DWINVER=0x0A00 -D_E
    NABLE_EXTENDED_ALIGNED_STORAGE -D_UNICODE -D_WIN32_WINNT=0x0A00 -D_WIN64 -IC:/msys64/home/kou/work/gr.build/grplot_autogen/include -IC:/msys64/home/kou/work/gr/lib/grm/include -IC:/msys64/home/kou/work/gr
    /lib/grm/src -IC:/msys64/home/kou/work/gr/lib/gks -IC:/msys64/home/kou/work/gr/lib/gr -IC:/msys64/home/kou/work/gr/lib/gr3 -isystem C:/msys64/clang64/include/qt6/QtWidgets -isystem C:/msys64/clang64/inclu
    de/qt6 -isystem C:/msys64/clang64/include/qt6/QtCore -isystem C:/msys64/clang64/share/qt6/mkspecs/win32-clang-g++ -isystem C:/msys64/clang64/include/qt6/QtGui -isystem C:/msys64/clang64/include/freetype2
    -O3 -DNDEBUG -fno-exceptions -Werror=implicit -pthread -std=c++17 -MD -MT CMakeFiles/grplot.dir/lib/grm/grplot/util.cxx.obj -MF CMakeFiles\grplot.dir\lib\grm\grplot\util.cxx.obj.d -o CMakeFiles/grplot.dir
    /lib/grm/grplot/util.cxx.obj -c C:/msys64/home/kou/work/gr/lib/grm/grplot/util.cxx
    In file included from C:/msys64/home/kou/work/gr/lib/grm/grplot/util.cxx:23:
    In file included from C:/msys64/clang64/include/c++/v1/array:127:
    In file included from C:/msys64/clang64/include/c++/v1/algorithm:1711:
    C:/msys64/clang64/include/c++/v1/cstring:72:9: error: no member named 'strcpy_instead_use_StringCbCopyA_or_StringCchCopyA' in the global namespace
    using ::strcpy _LIBCPP_USING_IF_EXISTS;
          ~~^
    C:/msys64/clang64/include/strsafe.h:1931:16: note: expanded from macro 'strcpy'
    #define strcpy strcpy_instead_use_StringCbCopyA_or_StringCchCopyA;
                   ^
    In file included from C:/msys64/home/kou/work/gr/lib/grm/grplot/util.cxx:23:
    In file included from C:/msys64/clang64/include/c++/v1/array:127:
    In file included from C:/msys64/clang64/include/c++/v1/algorithm:1711:
    C:/msys64/clang64/include/c++/v1/cstring:74:9: error: no member named 'strcat_instead_use_StringCbCatA_or_StringCchCatA' in the global namespace
    using ::strcat _LIBCPP_USING_IF_EXISTS;
          ~~^
    C:/msys64/clang64/include/strsafe.h:1937:16: note: expanded from macro 'strcat'
    #define strcat strcat_instead_use_StringCbCatA_or_StringCchCatA;
                   ^
    In file included from C:/msys64/home/kou/work/gr/lib/grm/grplot/util.cxx:25:
    In file included from C:/msys64/clang64/include/c++/v1/iostream:41:
    In file included from C:/msys64/clang64/include/c++/v1/ios:221:
    In file included from C:/msys64/clang64/include/c++/v1/__locale:19:
    In file included from C:/msys64/clang64/include/c++/v1/mutex:191:
    In file included from C:/msys64/clang64/include/c++/v1/__mutex_base:20:
    In file included from C:/msys64/clang64/include/c++/v1/system_error:151:
    In file included from C:/msys64/clang64/include/c++/v1/string:536:
    In file included from C:/msys64/clang64/include/c++/v1/__string/char_traits.h:21:
    C:/msys64/clang64/include/c++/v1/cstdio:119:9: error: no member named 'sprintf_instead_use_StringCbPrintfA_or_StringCchPrintfA' in the global namespace
    using ::sprintf _LIBCPP_USING_IF_EXISTS;
          ~~^
    C:/msys64/clang64/include/strsafe.h:1943:17: note: expanded from macro 'sprintf'
    #define sprintf sprintf_instead_use_StringCbPrintfA_or_StringCchPrintfA;
                    ^
    In file included from C:/msys64/home/kou/work/gr/lib/grm/grplot/util.cxx:25:
    In file included from C:/msys64/clang64/include/c++/v1/iostream:41:
    In file included from C:/msys64/clang64/include/c++/v1/ios:221:
    In file included from C:/msys64/clang64/include/c++/v1/__locale:19:
    In file included from C:/msys64/clang64/include/c++/v1/mutex:191:
    In file included from C:/msys64/clang64/include/c++/v1/__mutex_base:20:
    In file included from C:/msys64/clang64/include/c++/v1/system_error:151:
    In file included from C:/msys64/clang64/include/c++/v1/string:536:
    In file included from C:/msys64/clang64/include/c++/v1/__string/char_traits.h:21:
    C:/msys64/clang64/include/c++/v1/cstdio:125:9: error: no member named 'vsprintf_instead_use_StringCbVPrintfA_or_StringCchVPrintfA' in the global namespace
    using ::vsprintf _LIBCPP_USING_IF_EXISTS;
          ~~^
    C:/msys64/clang64/include/strsafe.h:1949:18: note: expanded from macro 'vsprintf'
    #define vsprintf vsprintf_instead_use_StringCbVPrintfA_or_StringCchVPrintfA;
                     ^
    In file included from C:/msys64/home/kou/work/gr/lib/grm/grplot/util.cxx:25:
    In file included from C:/msys64/clang64/include/c++/v1/iostream:41:
    In file included from C:/msys64/clang64/include/c++/v1/ios:221:
    In file included from C:/msys64/clang64/include/c++/v1/__locale:19:
    In file included from C:/msys64/clang64/include/c++/v1/mutex:191:
    In file included from C:/msys64/clang64/include/c++/v1/__mutex_base:20:
    In file included from C:/msys64/clang64/include/c++/v1/system_error:151:
    In file included from C:/msys64/clang64/include/c++/v1/string:536:
    In file included from C:/msys64/clang64/include/c++/v1/__string/char_traits.h:27:
    C:/msys64/clang64/include/c++/v1/cwchar:123:9: error: no member named 'swprintf_instead_use_StringCbPrintfW_or_StringCchPrintfW' in the global namespace
    using ::swprintf _LIBCPP_USING_IF_EXISTS;
          ~~^
    C:/msys64/clang64/include/strsafe.h:1946:18: note: expanded from macro 'swprintf'
    #define swprintf swprintf_instead_use_StringCbPrintfW_or_StringCchPrintfW;
                     ^
    In file included from C:/msys64/home/kou/work/gr/lib/grm/grplot/util.cxx:25:
    In file included from C:/msys64/clang64/include/c++/v1/iostream:41:
    In file included from C:/msys64/clang64/include/c++/v1/ios:221:
    In file included from C:/msys64/clang64/include/c++/v1/__locale:19:
    In file included from C:/msys64/clang64/include/c++/v1/mutex:191:
    In file included from C:/msys64/clang64/include/c++/v1/__mutex_base:20:
    In file included from C:/msys64/clang64/include/c++/v1/system_error:151:
    In file included from C:/msys64/clang64/include/c++/v1/string:536:
    In file included from C:/msys64/clang64/include/c++/v1/__string/char_traits.h:27:
    C:/msys64/clang64/include/c++/v1/cwchar:125:9: error: no member named 'vswprintf_instead_use_StringCbVPrintfW_or_StringCchVPrintfW' in the global namespace
    using ::vswprintf _LIBCPP_USING_IF_EXISTS;
          ~~^
    C:/msys64/clang64/include/strsafe.h:1952:19: note: expanded from macro 'vswprintf'
    #define vswprintf vswprintf_instead_use_StringCbVPrintfW_or_StringCchVPrintfW;
                      ^
    In file included from C:/msys64/home/kou/work/gr/lib/grm/grplot/util.cxx:25:
    In file included from C:/msys64/clang64/include/c++/v1/iostream:41:
    In file included from C:/msys64/clang64/include/c++/v1/ios:221:
    In file included from C:/msys64/clang64/include/c++/v1/__locale:19:
    In file included from C:/msys64/clang64/include/c++/v1/mutex:191:
    In file included from C:/msys64/clang64/include/c++/v1/__mutex_base:20:
    In file included from C:/msys64/clang64/include/c++/v1/system_error:151:
    In file included from C:/msys64/clang64/include/c++/v1/string:536:
    In file included from C:/msys64/clang64/include/c++/v1/__string/char_traits.h:27:
    C:/msys64/clang64/include/c++/v1/cwchar:144:9: error: no member named 'wcscpy_instead_use_StringCbCopyW_or_StringCchCopyW' in the global namespace
    using ::wcscpy _LIBCPP_USING_IF_EXISTS;
          ~~^
    C:/msys64/clang64/include/strsafe.h:1934:16: note: expanded from macro 'wcscpy'
    #define wcscpy wcscpy_instead_use_StringCbCopyW_or_StringCchCopyW;
                   ^
    In file included from C:/msys64/home/kou/work/gr/lib/grm/grplot/util.cxx:25:
    In file included from C:/msys64/clang64/include/c++/v1/iostream:41:
    In file included from C:/msys64/clang64/include/c++/v1/ios:221:
    In file included from C:/msys64/clang64/include/c++/v1/__locale:19:
    In file included from C:/msys64/clang64/include/c++/v1/mutex:191:
    In file included from C:/msys64/clang64/include/c++/v1/__mutex_base:20:
    In file included from C:/msys64/clang64/include/c++/v1/system_error:151:
    In file included from C:/msys64/clang64/include/c++/v1/string:536:
    In file included from C:/msys64/clang64/include/c++/v1/__string/char_traits.h:27:
    C:/msys64/clang64/include/c++/v1/cwchar:146:9: error: no member named 'wcscat_instead_use_StringCbCatW_or_StringCchCatW' in the global namespace
    using ::wcscat _LIBCPP_USING_IF_EXISTS;
          ~~^
    C:/msys64/clang64/include/strsafe.h:1940:16: note: expanded from macro 'wcscat'
    #define wcscat wcscat_instead_use_StringCbCatW_or_StringCchCatW;
                   ^
    C:/msys64/home/kou/work/gr/lib/grm/grplot/util.cxx:102:8: error: no matching function for call to 'FormatMessageW'
      if (!FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
           ^~~~~~~~~~~~~
    C:/msys64/clang64/include/winbase.h:1443:23: note: expanded from macro 'FormatMessage'
    #define FormatMessage __MINGW_NAME_AW(FormatMessage)
                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    C:/msys64/clang64/include/_mingw_unicode.h:12:32: note: expanded from macro '__MINGW_NAME_AW'
    # define __MINGW_NAME_AW(func) func##W
                                   ^~~~~~~
    <scratch space>:220:1: note: expanded from here
    FormatMessageW
    ^~~~~~~~~~~~~~
    C:/msys64/clang64/include/winbase.h:1441:27: note: candidate function not viable: no known conversion from 'LPSTR' (aka 'char *') to 'LPWSTR' (aka 'wchar_t *') for 5th argument
      WINBASEAPI DWORD WINAPI FormatMessageW (DWORD dwFlags, LPCVOID lpSource, DWORD dwMessageId, DWORD dwLanguageId, LPWSTR lpBuffer, DWORD nSize, va_list *Arguments);
                              ^
    9 errors generated.

See also: https://github.com/msys2/MINGW-packages/pull/14675