### PR TITLE
export gr_setwscharheight in windows dlls

### DIFF
--- a/lib/gr/gr.h
+++ b/lib/gr/gr.h
@@ -274,6 +274,7 @@ DLLEXPORT void gr_volume_interp_gauss_init(double, double *);
 DLLEXPORT double gr_volume_interp_tri_linear(const data_point3d_t *, const void *, const point3d_t *,
                                              const point3d_t *);
 DLLEXPORT double gr_volume_interp_gauss(const data_point3d_t *, const void *, const point3d_t *, const point3d_t *);
+DLLEXPORT void gr_setwscharheight(double chh, double height);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
pyinstaller on windows fails with:

```
 File "C:\Program Files (x86)\Microsoft Visual Studio\Shared\Python39_64\lib\runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "C:\Program Files (x86)\Microsoft Visual Studio\Shared\Python39_64\lib\runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "C:\Users\jenkins\workspace\Generic\BuildPyWinExe\installvenv\Scripts\pyinstaller.exe\__main__.py", line 7, in <module>
  File "C:\Users\jenkins\workspace\Generic\BuildPyWinExe\installvenv\lib\site-packages\PyInstaller\__main__.py", line 194, in _console_script_run
    run()
  File "C:\Users\jenkins\workspace\Generic\BuildPyWinExe\installvenv\lib\site-packages\PyInstaller\__main__.py", line 180, in run
    run_build(pyi_config, spec_file, **vars(args))
  File "C:\Users\jenkins\workspace\Generic\BuildPyWinExe\installvenv\lib\site-packages\PyInstaller\__main__.py", line 61, in run_build
    PyInstaller.building.build_main.main(pyi_config, spec_file, **kwargs)
  File "C:\Users\jenkins\workspace\Generic\BuildPyWinExe\installvenv\lib\site-packages\PyInstaller\building\build_main.py", line 971, in main
    build(specfile, distpath, workpath, clean_build)
  File "C:\Users\jenkins\workspace\Generic\BuildPyWinExe\installvenv\lib\site-packages\PyInstaller\building\build_main.py", line 893, in build
    exec(code, spec_namespace)
  File "C:\Users\jenkins\workspace\Generic\BuildPyWinExe\installer\nicos-history.spec", line 8, in <module>
    from utils import rootdir, find_uis, find_custom, find_gr, find_modules
  File "C:\Users\jenkins\workspace\Generic\BuildPyWinExe\installer\utils.py", line 31, in <module>
    import gr
  File "C:\Users\jenkins\workspace\Generic\BuildPyWinExe\installvenv\lib\site-packages\gr\__init__.py", line 3887, in <module>
    __gr.gr_setwscharheight.argtypes = [c_double, c_double]
  File "C:\Program Files (x86)\Microsoft Visual Studio\Shared\Python39_64\lib\ctypes\__init__.py", line 387, in __getattr__
    func = self.__getitem__(name)
  File "C:\Program Files (x86)\Microsoft Visual Studio\Shared\Python39_64\lib\ctypes\__init__.py", line 392, in __getitem__
    func = self._FuncPtr((name_or_ordinal, self))
AttributeError: function 'gr_setwscharheight' not found
```