### PR TITLE
Fix build with recent mingw-w64 targetting ucrt

### DIFF
--- a/lib/gks/font.c
+++ b/lib/gks/font.c
@@ -15,7 +15,6 @@
 
 #if defined(_WIN32)
 #define STRSAFE_NO_DEPRECATE
-#define _CRT_NON_CONFORMING_WCSTOK
 #define __STRSAFE__NO_INLINE
 #include <windows.h>
 #include <strsafe.h>

--- a/lib/gks/ft.c
+++ b/lib/gks/ft.c
@@ -340,6 +340,11 @@ static int ft_search_file_in_dir(const ft_path_char_t *base_dir, const ft_path_c
 static int ft_find_font(const ft_path_char_t *filename, ft_path_char_t *result)
 {
 #if defined(_WIN32)
+  #ifndef _UCRT
+    /* for mingw-w64 targeting msvcrt */
+    #define wcstok(strToken, strDelimit, context) wcstok(strToken, strDelimit)
+  #endif
+
   const ft_path_char_t **font_directory;
   ft_path_char_t abspath[MAXPATHLEN];
   ft_path_char_t env[MAXPATHLEN];
@@ -354,14 +359,15 @@ static int ft_find_font(const ft_path_char_t *filename, ft_path_char_t *result)
   /* search paths from `GKS_FONT_DIRS` environment variable */
   if (GetEnvironmentVariableW(L"GKS_FONT_DIRS", env, MAXPATHLEN))
     {
-      gks_font_dir = wcstok(env, delim);
+      wchar_t *buffer;
+      gks_font_dir = wcstok(env, delim, &buffer);
       while (gks_font_dir)
         {
           if (ft_search_file_in_dir(gks_font_dir, filename, result, 0))
             {
               return 1;
             }
-          gks_font_dir = wcstok(NULL, delim);
+          gks_font_dir = wcstok(NULL, delim, &buffer);
         }
     }
 


### PR DESCRIPTION
mingw-w64 targeting ucrt doesn't support _CRT_NON_CONFORMING_WCSTOK and only provides the newer wcstok(), so get rid of _CRT_NON_CONFORMING_WCSTOK and port the code the the thread-safe variant.

This in turn leads to a problem with mingw-w64 targeting old msvcrt, which only has the old wcstok(), so add a macro to make it use the old version there.

Note that this likely dropps support for Visual Studio 2013, since only 2015 has the new wcstok()

(the signature of wcstok() was recently fixed in mingw-w64 master, uncovering this issue, see https://github.com/mingw-w64/mingw-w64/commit/40134887fb81f5be451b5c4c)