### PR TITLE
Replace relative CMake paths with absolute ones

### DIFF
--- a/gks.pc.in
+++ b/gks.pc.in
@@ -1,6 +1,6 @@
 prefix=@CMAKE_INSTALL_PREFIX@
-libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
-includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
 sopath=${libdir}/libGKS@GR_SHARED_LIBRARY_SUFFIX@
 
 Name: GKS

--- a/gr.pc.in
+++ b/gr.pc.in
@@ -1,6 +1,6 @@
 prefix=@CMAKE_INSTALL_PREFIX@
-libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
-includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
 sopath=${libdir}/libGR@GR_SHARED_LIBRARY_SUFFIX@
 
 Name: GR

--- a/gr3.pc.in
+++ b/gr3.pc.in
@@ -1,6 +1,6 @@
 prefix=@CMAKE_INSTALL_PREFIX@
-libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
-includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
 sopath=${libdir}/libGR3@GR_SHARED_LIBRARY_SUFFIX@
 
 Name: GR3

--- a/grm.pc.in
+++ b/grm.pc.in
@@ -1,6 +1,6 @@
 prefix=@CMAKE_INSTALL_PREFIX@
-libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
-includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
 sopath=${libdir}/libGRM@GR_SHARED_LIBRARY_SUFFIX@
 
 Name: GRM


### PR DESCRIPTION
See the reasoning here: https://github.com/jtojnar/cmake-snips#assuming-cmake_install_dir-is-relative-path

This affects https://github.com/NixOS/nixpkgs/pull/238469.