### PR TITLE
Fix `cbDest` argument of `StringCbPrintfW`

### DIFF
--- a/lib/gks/ft.c
+++ b/lib/gks/ft.c
@@ -234,7 +234,7 @@ static int ft_join_path(ft_path_char_t *result, size_t size, const ft_path_char_
       return 0;
     }
 
-  StringCbPrintfW(result, size, L"%ws%c%ws", first, delim, second);
+  StringCbPrintfW(result, size * sizeof(wchar_t), L"%ws%c%ws", first, delim, second);
   return 1;
 #else
   const char delim = '/';
@@ -728,7 +728,7 @@ static ft_path_char_t *gks_ft_get_font_path(const char *font_name, const char *f
   StringCbLengthW(prefix, MAXPATHLEN, &len);
   len += 2 * (7 + strlen(font_name) + strlen(font_file_extension) + 1);
   font_path = (ft_path_char_t *)gks_malloc(len * sizeof(ft_path_char_t));
-  StringCbPrintfW(font_path, MAXPATHLEN, L"%lS\\FONTS\\%S%S", prefix, font_name, font_file_extension);
+  StringCbPrintfW(font_path, len * sizeof(ft_path_char_t), L"%lS\\FONTS\\%S%S", prefix, font_name, font_file_extension);
 #else
   const char *prefix;
   char *font_path;

--- a/lib/gks/plugin.c
+++ b/lib/gks/plugin.c
@@ -49,8 +49,11 @@ static void *load_library(const char *name)
   handle = LoadLibrary(pathname);
   if (handle == NULL)
     {
-      GetEnvironmentVariableW(L"GRDIR", grdir, MAX_PATH);
-      StringCbPrintfW(w_pathname, MAX_PATH, L"%ws\\bin\\%S.%S", grdir, name, EXTENSION);
+      if (!GetEnvironmentVariableW(L"GRDIR", grdir, MAX_PATH))
+        {
+          MultiByteToWideChar(CP_UTF8, 0, GRDIR, -1, grdir, MAX_PATH);
+        }
+      StringCbPrintfW(w_pathname, sizeof(w_pathname), L"%ws\\bin\\%S.%S", grdir, name, EXTENSION);
       handle = LoadLibraryExW(w_pathname, NULL, LOAD_WITH_ALTERED_SEARCH_PATH);
       if (handle == NULL)
         {

--- a/lib/gks/socket.c
+++ b/lib/gks/socket.c
@@ -81,7 +81,7 @@ static DWORD WINAPI gksqt_thread(LPVOID parm)
   STARTUPINFOW startupInfo;
   PROCESS_INFORMATION processInformation;
 
-  StringCbPrintfW(w_cmd_line, CMD_LINE_LEN, L"cmd.exe /c \"%ls\"", cmd);
+  StringCbPrintfW(w_cmd_line, sizeof(w_cmd_line), L"cmd.exe /c \"%ls\"", cmd);
 
   if (!GetEnvironmentVariableW(L"WSLENV", buffer, BUFFER_LEN))
     {
@@ -305,11 +305,11 @@ static int open_socket(int wstype)
         {
           if (!GetEnvironmentVariableW(L"GRDIR", w_env, MAXPATHLEN))
             {
-              StringCbPrintfW(command, CMD_LINE_LEN, L"%S\\bin\\gksqt.exe", GRDIR);
+              StringCbPrintfW(command, sizeof(command), L"%S\\bin\\gksqt.exe", GRDIR);
             }
           else
             {
-              StringCbPrintfW(command, CMD_LINE_LEN, L"%ws\\bin\\gksqt.exe", w_env);
+              StringCbPrintfW(command, sizeof(command), L"%ws\\bin\\gksqt.exe", w_env);
             }
         }
 #else

--- a/lib/gr/stream.c
+++ b/lib/gr/stream.c
@@ -318,7 +318,7 @@ static DWORD WINAPI grplot_thread(LPVOID parm)
   STARTUPINFOW startupInfo;
   PROCESS_INFORMATION processInformation;
 
-  StringCbPrintfW(w_cmd_line, CMD_LINE_LEN, L"cmd /c \"%ls\"", cmd);
+  StringCbPrintfW(w_cmd_line, sizeof(w_cmd_line), L"cmd /c \"%ls\"", cmd);
 
   ZeroMemory(&startupInfo, sizeof(startupInfo));
   startupInfo.cb = sizeof(startupInfo);
@@ -520,11 +520,11 @@ int gr_startlistener(void)
     {
       if (!GetEnvironmentVariableW(L"GRDIR", w_env, MAXPATHLEN))
         {
-          StringCbPrintfW(command, CMD_LINE_LEN, L"%S\\bin\\grplot.exe --listen %i", GRDIR, grplot_port);
+          StringCbPrintfW(command, sizeof(command), L"%S\\bin\\grplot.exe --listen %i", GRDIR, grplot_port);
         }
       else
         {
-          StringCbPrintfW(command, CMD_LINE_LEN, L"%s\\bin\\grplot.exe --listen %i", w_env, grplot_port);
+          StringCbPrintfW(command, sizeof(command), L"%s\\bin\\grplot.exe --listen %i", w_env, grplot_port);
         }
     }
 #else


### PR DESCRIPTION
Microsoft has documented that this is the size of the destination buffer in bytes, not characters:
> The size of the destination buffer, in bytes. This value must be sufficiently large to accommodate the final formatted string plus the terminating null character. The maximum number of bytes allowed is STRSAFE_MAX_CCH * sizeof(TCHAR).

PATH_MAX is already limited to 260 on Windows, so this mistake means that paths longer than ~130 characters are truncated.