### PR TITLE
Fix segfault in grm_export when no figure is active

### DIFF
--- a/lib/grm/src/grm/plot.cxx
+++ b/lib/grm/src/grm/plot.cxx
@@ -6975,8 +6975,12 @@ int grm_process_tree(void)
 int grm_export(const char *file_path, int export_xml)
 {
   auto active_figure = global_root->querySelectors("figure[active=\"1\"]");
-  auto active_plot = active_figure->querySelectors("plot[_active=\"1\"]");
-  auto active_plot_through_update = active_figure->querySelectors("plot[_active_through_update=\"1\"]");
+  std::shared_ptr<GRM::Element> active_plot, active_plot_through_update;
+  if (active_figure != nullptr)
+    {
+      active_plot = active_figure->querySelectors("plot[_active=\"1\"]");
+      active_plot_through_update = active_figure->querySelectors("plot[_active_through_update=\"1\"]");
+    }
 
   if (active_plot != nullptr) active_plot->setAttribute("_active", 0);
   if (active_plot_through_update != nullptr) active_plot_through_update->setAttribute("_active_through_update", 0);


### PR DESCRIPTION
Fixes GH-204

`grm_export()` segfaults when called with no active figure (the `grm_merge()` -> `grm_export()` sequence), a regression since b7520a3c (first released in v0.73.23): it dereferences `querySelectors("figure[active=\"1\"]")` without a nullptr check, and when nothing has been plotted yet there is no such element. Reproduction and backtrace are in GH-204.

## Fix

Guard the plot lookups with a nullptr check, matching the existing `active_plot` / `active_plot_through_update` checks directly below. Exporting without a prior `grm_plot()` is a valid sequence — the rendering is done by the `grm_plot(nullptr)` call further down; the `_active` flag handling added in b7520a3c only matters when a figure already exists, so when there is none there are simply no flags to clear.

## Verification

Built `develop` from source (`-DGR_USE_BUNDLED_LIBRARIES=OFF`): the reproduction from GH-204 crashes without this patch and, with it applied, exits cleanly and writes a valid PDF. The crash boundary in the official binaries (v0.73.22 works, v0.73.23+ crash) matches b7520a3c's first release, and `develop` still contains the unguarded code.