### PR TITLE
Rename header guard from _IO_H_ to _STREAM_H_ in gr/stream.h

### DIFF
--- a/lib/gr/stream.h
+++ b/lib/gr/stream.h
@@ -1,5 +1,5 @@
-#ifndef _IO_H_
-#define _IO_H_
+#ifndef _STREAM_H_
+#define _STREAM_H_
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
The Windows header `io.h` define the same header guard, at least MinGW headers do. See (https://github.com/mingw-w64/mingw-w64/blob/master/mingw-w64-headers/crt/io.h).

This causes functions like `gr_openstream()` and friends to not be found while building `gr`.

Here's an example when building with Clang:
```
[33/360] Building C object CMakeFiles/gr_shared.dir/lib/gr/gr.c.obj
FAILED: [code=1] CMakeFiles/gr_shared.dir/lib/gr/gr.c.obj
C:\msys64\clang64\bin\clang.exe -DGRDIR=\"/clang64\" -Dgr_shared_EXPORTS -ID:/M_P/mingw-w64-gr/src/gr-0.73.26/lib/gr -ID:/M_P/mingw-w64-gr/src/build-CLANG64 -ID:/M_P/mingw-w64-gr/src/gr-0.73.26/lib/gks -march=nocona -msahf -mtune=generic -O2 -pipe -Wp,-D_FORTIFY_SOURCE=2 -fstack-protector-strong -Wp,-D__USE_MINGW_ANSI_STDIO=1 -O3 -DNDEBUG -std=c90 -pthread -Werror=implicit -MD -MT CMakeFiles/gr_shared.dir/lib/gr/gr.c.obj -MF CMakeFiles\gr_shared.dir\lib\gr\gr.c.obj.d -o CMakeFiles/gr_shared.dir/lib/gr/gr.c.obj -c D:/M_P/mingw-w64-gr/src/gr-0.73.26/lib/gr/gr.c
D:/M_P/mingw-w64-gr/src/gr-0.73.26/lib/gr/gr.c:1443:7: warning: assigning to 'char *' from 'const char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
 1443 |   env = gks_getenv("GR_SCALE_FACTOR");
      |       ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
D:/M_P/mingw-w64-gr/src/gr-0.73.26/lib/gr/gr.c:1531:11: error: implicit declaration of function 'gr_openstream' [-Werror,-Wimplicit-function-declaration]
 1531 |       if (gr_openstream(display) == 0)
      |           ^
D:/M_P/mingw-w64-gr/src/gr-0.73.26/lib/gr/gr.c:1533:11: error: implicit declaration of function 'gr_writestream' [-Werror,-Wimplicit-function-declaration]
 1533 |           gr_writestream(XML_HEADER);
 ```